### PR TITLE
Refactor the autoload process in the bin script.

### DIFF
--- a/bin/graph-composer
+++ b/bin/graph-composer
@@ -1,7 +1,14 @@
 #!/usr/bin/env php
 <?php
 
-(@include __DIR__ . '/../vendor/autoload.php') OR (@include __DIR__ . '/../../../../vendor/autoload.php') OR fwrite(STDERR, 'ERROR: Composer not properly set up! Run "composer install" or see README.md for more details' . PHP_EOL) AND exit(1);
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require __DIR__ . '/../vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require __DIR__ . '/../../../autoload.php';
+} else {
+    fwrite(STDERR, 'ERROR: Composer dependencies not properly set up! Run "composer install" or see README.md for more details' . PHP_EOL);
+    exit(1);
+}
 
 $app = new Clue\GraphComposer\App();
 $app->run();


### PR DESCRIPTION
This is a bit easier to understand I think.

It also uses require rather than include, so that failure to properly load the file terminates the script.

It also removes the error suppression which can silence unwanted errors (It will silence any errors that occur while parsing the related class (and any other files included in the process)).
