### PR TITLE
Add options to exclude packages and dependencies from graph.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## ?.?.? (unreleased)
+
+* Dev dependencies are only rendered for the root package
+
+* Added new options to filter packages and dependencies:
+    * `--no-dev` will hide dev dependencies
+    * `--no-php` will hide the constraints regarding the PHP version
+    * `--no-ext` will hide PHP extensions
+    * `--depth` will limit the depth of the generated graph
+    * `--exclude-regex` allows to apply regular expressions to hide packages
+    * `--only-regex` show only packages with their name matching the expression
+    * `--exclude-type` exclude pacakges with given type
+    * `--only-type` only show packages of given type
+
 ## 1.0.0 (2015-11-17)
 
 *   First stable release, now following SemVer.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ $ php graph-composer.phar export ~/path/to/your/project
 *   You may optionally pass an `--format=[svg/svgz/png/jpeg/...]` option to set
     the image type (defaults to `svg`).
 
+### Options
+
+|Option          |Description                                                     |Example                                                    |
+|----------------|----------------------------------------------------------------|-----------------------------------------------------------|
+|--format        |Image format (`svg`, `png` or `jpeg`), default `svg`            |`graph-composer show --format png`                         |
+|--no-dev        |Hides dev dependencies                                          |`graph-composer show --no-dev`                             |
+|--no-php        |Hides dependency to PHP version                                 |`graph-composer show --no-php`                             |
+|--no-ext        |Hides dependency to PHP extensions                              |`graph-composer show --no-ext`                             |
+|--depth         |Stops rendering the graph at the given depth                    |`graph-composer show --depth 3`                            |
+|--exclude-regex |Hides packages that are matching the regular expression         |`graph-composer show --exclude-regex "#^phpunit/#"`        |
+|--only-regex    |Hides packages that are **not** matching the regular expression |`graph-composer show --only-regex "#^mycompany/#"`         |
+|--exclude-type  |Hides packages that are of the given type                       |`graph-composer show --exclude-type "typo3-cms-framework"` |
+|--only-type     |Hides packages that are **not** of the given type               |`graph-composer show --only-type "typo3-cms-framework"`    |
+
 ## Install
 
 You can grab a copy of clue/graph-composer in either of the following ways.

--- a/src/Clue/GraphComposer/Command/AbstractCommand.php
+++ b/src/Clue/GraphComposer/Command/AbstractCommand.php
@@ -2,9 +2,64 @@
 
 namespace Clue\GraphComposer\Command;
 
+use Clue\GraphComposer\Exclusion\Dependency\ChainedDependencyRule;
+use Clue\GraphComposer\Exclusion\Dependency\NoDevDependencyRule;
+use Clue\GraphComposer\Exclusion\Package\ChainedPackageRule;
+use Clue\GraphComposer\Exclusion\Package\ExcludeByNamePackageRule;
+use Clue\GraphComposer\Exclusion\Package\NoPhpExtensionRule;
+use Clue\GraphComposer\Graph\GraphComposer;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 class AbstractCommand extends Command
 {
+    protected function configure()
+    {
+        $this
+            ->addArgument('dir', InputArgument::OPTIONAL, 'Path to project directory to scan', '.')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Image format (svg, png, jpeg)', 'svg')
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Removes dev dependencies from the generated graph')
+            ->addOption('no-php', null, InputOption::VALUE_NONE, 'Hides dependency to PHP')
+            ->addOption('no-ext', null, InputOption::VALUE_NONE, 'Hide PHP extensions')
+            ->addOption('depth', null, InputOption::VALUE_REQUIRED, 'Set the maximum depth of dependency graph', PHP_INT_MAX)
+            ->addOption('exclude-regex', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Excludes packages using a regular expression like #^phpunit/.*/$#');
+    }
 
+    /**
+     * @param InputInterface $input
+     * @return GraphComposer
+     */
+    protected function createGraph(InputInterface $input)
+    {
+        $dependencyRule = new ChainedDependencyRule();
+        if ($input->getOption('no-dev')) {
+            $dependencyRule->add(new NoDevDependencyRule());
+        }
+
+        $packageRule = new ChainedPackageRule();
+        if ($input->getOption('no-php')) {
+            $packageRule->add(new ExcludeByNamePackageRule('#^php$#'));
+        }
+
+        if ($input->getOption('no-ext')) {
+            $packageRule->add(new NoPhpExtensionRule());
+        }
+
+        foreach ($input->getOption('exclude-regex') as $regex) {
+            $packageRule->add(new ExcludeByNamePackageRule($regex));
+        }
+
+        $graph = new GraphComposer(
+            $input->getArgument('dir'),
+            null,
+            $packageRule,
+            $dependencyRule,
+            (int)$input->getOption('depth')
+        );
+        $graph->setFormat($input->getOption('format'));
+
+        return $graph;
+    }
 }

--- a/src/Clue/GraphComposer/Command/AbstractCommand.php
+++ b/src/Clue/GraphComposer/Command/AbstractCommand.php
@@ -6,6 +6,8 @@ use Clue\GraphComposer\Exclusion\Dependency\ChainedDependencyRule;
 use Clue\GraphComposer\Exclusion\Dependency\NoDevDependencyRule;
 use Clue\GraphComposer\Exclusion\Package\ChainedPackageRule;
 use Clue\GraphComposer\Exclusion\Package\ExcludeByNamePackageRule;
+use Clue\GraphComposer\Exclusion\Package\ExcludeTypePackageRule;
+use Clue\GraphComposer\Exclusion\Package\NegatePackageRule;
 use Clue\GraphComposer\Exclusion\Package\NoPhpExtensionRule;
 use Clue\GraphComposer\Graph\GraphComposer;
 use Symfony\Component\Console\Command\Command;
@@ -24,7 +26,11 @@ class AbstractCommand extends Command
             ->addOption('no-php', null, InputOption::VALUE_NONE, 'Hides dependency to PHP')
             ->addOption('no-ext', null, InputOption::VALUE_NONE, 'Hide PHP extensions')
             ->addOption('depth', null, InputOption::VALUE_REQUIRED, 'Set the maximum depth of dependency graph', PHP_INT_MAX)
-            ->addOption('exclude-regex', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Excludes packages using a regular expression like #^phpunit/.*/$#');
+            ->addOption('exclude-regex', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Excludes packages using a regular expression like #^phpunit/.*/$#')
+            ->addOption('only-regex', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Includes only packages using a regular expression like #^phpunit/.*/$#')
+            ->addOption('exclude-type', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Excludes packages of given type.')
+            ->addOption('only-type', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Includes only packages of given type.')
+        ;
     }
 
     /**
@@ -49,6 +55,28 @@ class AbstractCommand extends Command
 
         foreach ($input->getOption('exclude-regex') as $regex) {
             $packageRule->add(new ExcludeByNamePackageRule($regex));
+        }
+
+        $onlyRegex = $input->getOption('only-regex');
+        if (count($onlyRegex)) {
+            $onlyRegexRule = new ChainedPackageRule();
+            foreach ($onlyRegex as $regex) {
+                $onlyRegexRule->add(new ExcludeByNamePackageRule($regex));
+            }
+            $packageRule->add(new NegatePackageRule($onlyRegexRule));
+        }
+
+        foreach ($input->getOption('exclude-type') as $type) {
+            $packageRule->add(new ExcludeTypePackageRule($type));
+        }
+
+        $onlyTypes = $input->getOption('only-type');
+        if (count($onlyTypes)) {
+            $onlyTypesRule = new ChainedPackageRule();
+            foreach ($onlyTypes as $type) {
+                $onlyTypesRule->add(new ExcludeTypePackageRule($type));
+            }
+            $packageRule->add(new NegatePackageRule($onlyTypesRule));
         }
 
         $graph = new GraphComposer(

--- a/src/Clue/GraphComposer/Command/AbstractCommand.php
+++ b/src/Clue/GraphComposer/Command/AbstractCommand.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Clue\GraphComposer\Command;
+
+use Symfony\Component\Console\Command\Command;
+
+class AbstractCommand extends Command
+{
+
+}

--- a/src/Clue/GraphComposer/Command/Export.php
+++ b/src/Clue/GraphComposer/Command/Export.php
@@ -2,31 +2,25 @@
 
 namespace Clue\GraphComposer\Command;
 
-use Symfony\Component\Console\Input\InputOption;
+use Clue\GraphComposer\Graph\GraphComposer;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Clue\GraphComposer\Graph\GraphComposer;
 
-class Export extends Command
+class Export extends AbstractCommand
 {
     protected function configure()
     {
+        parent::configure();
+
         $this->setName('export')
              ->setDescription('Export dependency graph image for given project directory')
-             ->addArgument('dir', InputArgument::OPTIONAL, 'Path to project directory to scan', '.')
-             ->addArgument('output', InputArgument::OPTIONAL, 'Path to output image file')
-
-             // add output format option. default value MUST NOT be given, because default is to overwrite with output extension
-             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Image format (svg, png, jpeg)'/*, 'svg'*/)
-
-           /*->addOption('dev', null, InputOption::VALUE_NONE, 'If set, Whether require-dev dependencies should be shown') */;
+             ->addArgument('output', InputArgument::OPTIONAL, 'Path to output image file');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $graph = new GraphComposer($input->getArgument('dir'));
+        $graph = $this->createGraph($input);
 
         $target = $input->getArgument('output');
         if ($target !== null) {
@@ -40,11 +34,6 @@ class Export extends Command
                 // extension found and not empty
                 $graph->setFormat(substr($filename, $pos + 1));
             }
-        }
-
-        $format = $input->getOption('format');
-        if ($format !== null) {
-            $graph->setFormat($format);
         }
 
         $path = $graph->getImagePath();

--- a/src/Clue/GraphComposer/Command/Show.php
+++ b/src/Clue/GraphComposer/Command/Show.php
@@ -2,62 +2,22 @@
 
 namespace Clue\GraphComposer\Command;
 
-use Clue\GraphComposer\Exclusion\Dependency\ChainedDependencyRule;
-use Clue\GraphComposer\Exclusion\Dependency\NoDevDependencyRule;
-use Clue\GraphComposer\Exclusion\Package\ChainedPackageRule;
-use Clue\GraphComposer\Exclusion\Package\ExcludeByNamePackageRule;
-use Clue\GraphComposer\Exclusion\Package\NoPhpExtensionRule;
-use Clue\GraphComposer\Graph\GraphComposer;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Show extends Command
+class Show extends AbstractCommand
 {
     protected function configure()
     {
-        $this->setName('show')
-            ->setDescription('Show dependency graph image for given project directory')
-            ->addArgument('dir', InputArgument::OPTIONAL, 'Path to project directory to scan', '.')
-            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Image format (svg, png, jpeg)', 'svg')
-            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Removes dev dependencies from the generated graph')
-            ->addOption('no-php', null, InputOption::VALUE_NONE, 'Hides dependency to PHP')
-            ->addOption('no-ext', null, InputOption::VALUE_NONE, 'Hide PHP extensions')
-            ->addOption('depth', null, InputOption::VALUE_REQUIRED, 'Set the maximum depth of dependency graph', PHP_INT_MAX)
-            ->addOption('exclude-regex', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Excludes packages using a regular expression like #^phpunit/.*/$#')
-        ;
+        parent::configure();
+        $this
+            ->setName('show')
+            ->setDescription('Show dependency graph image for given project directory');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $dependencyRule = new ChainedDependencyRule();
-        if ($input->getOption('no-dev')) {
-            $dependencyRule->add(new NoDevDependencyRule());
-        }
-
-        $packageRule = new ChainedPackageRule();
-        if ($input->getOption('no-php')) {
-            $packageRule->add(new ExcludeByNamePackageRule('#^php$#'));
-        }
-
-        if ($input->getOption('no-ext')) {
-            $packageRule->add(new NoPhpExtensionRule());
-        }
-
-        foreach ($input->getOption('exclude-regex') as $regex) {
-            $packageRule->add(new ExcludeByNamePackageRule($regex));
-        }
-
-        $graph = new GraphComposer(
-            $input->getArgument('dir'),
-            null,
-            $packageRule,
-            $dependencyRule,
-            (int) $input->getOption('depth')
-        );
-        $graph->setFormat($input->getOption('format'));
+        $graph = $this->createGraph($input);
         $graph->displayGraph();
     }
 }

--- a/src/Clue/GraphComposer/Command/Show.php
+++ b/src/Clue/GraphComposer/Command/Show.php
@@ -2,27 +2,61 @@
 
 namespace Clue\GraphComposer\Command;
 
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use Clue\GraphComposer\Exclusion\Dependency\ChainedDependencyRule;
+use Clue\GraphComposer\Exclusion\Dependency\NoDevDependencyRule;
+use Clue\GraphComposer\Exclusion\Package\ChainedPackageRule;
+use Clue\GraphComposer\Exclusion\Package\ExcludeByNamePackageRule;
+use Clue\GraphComposer\Exclusion\Package\NoPhpExtensionRule;
 use Clue\GraphComposer\Graph\GraphComposer;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class Show extends Command
 {
     protected function configure()
     {
         $this->setName('show')
-             ->setDescription('Show dependency graph image for given project directory')
-             ->addArgument('dir', InputArgument::OPTIONAL, 'Path to project directory to scan', '.')
-             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Image format (svg, png, jpeg)', 'svg')
-           /*->addOption('dev', null, InputOption::VALUE_NONE, 'If set, Whether require-dev dependencies should be shown') */;
+            ->setDescription('Show dependency graph image for given project directory')
+            ->addArgument('dir', InputArgument::OPTIONAL, 'Path to project directory to scan', '.')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'Image format (svg, png, jpeg)', 'svg')
+            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Removes dev dependencies from the generated graph')
+            ->addOption('no-php', null, InputOption::VALUE_NONE, 'Hides dependency to PHP')
+            ->addOption('no-ext', null, InputOption::VALUE_NONE, 'Hide PHP extensions')
+            ->addOption('depth', null, InputOption::VALUE_REQUIRED, 'Set the maximum depth of dependency graph', PHP_INT_MAX)
+            ->addOption('exclude-regex', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Excludes packages using a regular expression like #^phpunit/.*/$#')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $graph = new GraphComposer($input->getArgument('dir'));
+        $dependencyRule = new ChainedDependencyRule();
+        if ($input->getOption('no-dev')) {
+            $dependencyRule->add(new NoDevDependencyRule());
+        }
+
+        $packageRule = new ChainedPackageRule();
+        if ($input->getOption('no-php')) {
+            $packageRule->add(new ExcludeByNamePackageRule('#^php$#'));
+        }
+
+        if ($input->getOption('no-ext')) {
+            $packageRule->add(new NoPhpExtensionRule());
+        }
+
+        foreach ($input->getOption('exclude-regex') as $regex) {
+            $packageRule->add(new ExcludeByNamePackageRule($regex));
+        }
+
+        $graph = new GraphComposer(
+            $input->getArgument('dir'),
+            null,
+            $packageRule,
+            $dependencyRule,
+            (int) $input->getOption('depth')
+        );
         $graph->setFormat($input->getOption('format'));
         $graph->displayGraph();
     }

--- a/src/Clue/GraphComposer/Exclusion/Dependency/ChainedDependencyRule.php
+++ b/src/Clue/GraphComposer/Exclusion/Dependency/ChainedDependencyRule.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Clue\GraphComposer\Exclusion\Dependency;
+
+use JMS\Composer\Graph\DependencyEdge;
+
+class ChainedDependencyRule implements DependencyRule
+{
+    /**
+     * @var DependencyRule[]
+     */
+    private $rules = array();
+
+    public function add(DependencyRule $rule)
+    {
+        $this->rules[] = $rule;
+    }
+
+    public function isExcluded(DependencyEdge $dependency)
+    {
+        foreach ($this->rules as $rule) {
+            if ($rule->isExcluded($dependency)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Clue/GraphComposer/Exclusion/Dependency/DependencyRule.php
+++ b/src/Clue/GraphComposer/Exclusion/Dependency/DependencyRule.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Clue\GraphComposer\Exclusion\Dependency;
+
+use JMS\Composer\Graph\DependencyEdge;
+
+interface DependencyRule
+{
+    public function isExcluded(DependencyEdge $dependency);
+}

--- a/src/Clue/GraphComposer/Exclusion/Dependency/NegateDependencyRule.php
+++ b/src/Clue/GraphComposer/Exclusion/Dependency/NegateDependencyRule.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Clue\GraphComposer\Exclusion\Dependency;
+
+use JMS\Composer\Graph\DependencyEdge;
+
+class NegateDependencyRule implements DependencyRule
+{
+    /**
+     * @var DependencyRule
+     */
+    private $rule;
+
+    public function __construct(DependencyRule $rule)
+    {
+        $this->rule = $rule;
+    }
+
+    public function isExcluded(DependencyEdge $dependency)
+    {
+        return !$this->rule->isExcluded($dependency);
+    }
+}

--- a/src/Clue/GraphComposer/Exclusion/Dependency/NoDevDependencyRule.php
+++ b/src/Clue/GraphComposer/Exclusion/Dependency/NoDevDependencyRule.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Clue\GraphComposer\Exclusion\Dependency;
+
+use JMS\Composer\Graph\DependencyEdge;
+
+class NoDevDependencyRule implements DependencyRule
+{
+    public function isExcluded(DependencyEdge $dependency)
+    {
+        if ($dependency->isDevDependency()) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Clue/GraphComposer/Exclusion/Package/ChainedPackageRule.php
+++ b/src/Clue/GraphComposer/Exclusion/Package/ChainedPackageRule.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Clue\GraphComposer\Exclusion\Package;
+
+use JMS\Composer\Graph\PackageNode;
+
+class ChainedPackageRule implements PackageRule
+{
+    /**
+     * @var PackageRule[]
+     */
+    private $rules = array();
+
+    public function add(PackageRule $rule)
+    {
+        $this->rules[] = $rule;
+    }
+
+    public function isExcluded(PackageNode $packageNode)
+    {
+        foreach ($this->rules as $rule) {
+            if ($rule->isExcluded($packageNode)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Clue/GraphComposer/Exclusion/Package/ExcludeByNamePackageRule.php
+++ b/src/Clue/GraphComposer/Exclusion/Package/ExcludeByNamePackageRule.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Clue\GraphComposer\Exclusion\Package;
+
+use JMS\Composer\Graph\PackageNode;
+
+class ExcludeByNamePackageRule implements PackageRule
+{
+    /**
+     * @var string
+     */
+    private $pattern;
+
+    public function __construct($pattern)
+    {
+        $this->pattern = $pattern;
+    }
+
+    public function isExcluded(PackageNode $package)
+    {
+        return preg_match($this->pattern, $package->getName());
+    }
+}

--- a/src/Clue/GraphComposer/Exclusion/Package/ExcludeTypePackageRule.php
+++ b/src/Clue/GraphComposer/Exclusion/Package/ExcludeTypePackageRule.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Clue\GraphComposer\Exclusion\Package;
+
+use JMS\Composer\Graph\PackageNode;
+
+class ExcludeTypePackageRule implements PackageRule
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    public function __construct($type)
+    {
+        $this->type = $type;
+    }
+
+    public function isExcluded(PackageNode $package)
+    {
+        $data = $package->getData();
+
+        if (!isset($data['type'])) {
+            return false;
+        }
+
+        return $data['type'] === $this->type;
+    }
+}

--- a/src/Clue/GraphComposer/Exclusion/Package/NegatePackageRule.php
+++ b/src/Clue/GraphComposer/Exclusion/Package/NegatePackageRule.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Clue\GraphComposer\Exclusion\Dependency;
+
+use Clue\GraphComposer\Exclusion\Package\PackageRule;
+use JMS\Composer\Graph\PackageNode;
+
+class NegatePackageRule implements PackageRule
+{
+    /**
+     * @var DependencyRule
+     */
+    private $rule;
+
+    public function __construct(PackageRule $rule)
+    {
+        $this->rule = $rule;
+    }
+
+    public function isExcluded(PackageNode $packageNode)
+    {
+        return !$this->rule->isExcluded($packageNode);
+    }
+}

--- a/src/Clue/GraphComposer/Exclusion/Package/NegatePackageRule.php
+++ b/src/Clue/GraphComposer/Exclusion/Package/NegatePackageRule.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace Clue\GraphComposer\Exclusion\Dependency;
+namespace Clue\GraphComposer\Exclusion\Package;
 
-use Clue\GraphComposer\Exclusion\Package\PackageRule;
 use JMS\Composer\Graph\PackageNode;
 
 class NegatePackageRule implements PackageRule

--- a/src/Clue/GraphComposer/Exclusion/Package/NoPhpExtensionRule.php
+++ b/src/Clue/GraphComposer/Exclusion/Package/NoPhpExtensionRule.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Clue\GraphComposer\Exclusion\Package;
+
+use JMS\Composer\Graph\PackageNode;
+
+class NoPhpExtensionRule implements PackageRule
+{
+    public function isExcluded(PackageNode $package)
+    {
+        if ($package->isPhpExtension()) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Clue/GraphComposer/Exclusion/Package/PackageRule.php
+++ b/src/Clue/GraphComposer/Exclusion/Package/PackageRule.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Clue\GraphComposer\Exclusion\Package;
+
+use JMS\Composer\Graph\PackageNode;
+
+interface PackageRule
+{
+    public function isExcluded(PackageNode $package);
+}

--- a/src/Clue/GraphComposer/Graph/GraphComposer.php
+++ b/src/Clue/GraphComposer/Graph/GraphComposer.php
@@ -76,13 +76,10 @@ class GraphComposer
 
         if ($packageExclusionRule === null) {
             $packageExclusionRule = new ChainedPackageRule();
-            //$packageExclusionRule->add(new NoPhpExtensionRule());
-            //$packageExclusionRule->add(new ExcludeByNamePackageRule('#^php$#'));
         }
 
         if ($dependencyExclusionRule === null) {
             $dependencyExclusionRule = new ChainedDependencyRule();
-            // $dependencyExclusionRule->add(new NoDevDependencyRule());
         }
 
         $analyzer = new \JMS\Composer\DependencyAnalyzer();

--- a/src/Clue/GraphComposer/Graph/GraphComposer.php
+++ b/src/Clue/GraphComposer/Graph/GraphComposer.php
@@ -2,10 +2,15 @@
 
 namespace Clue\GraphComposer\Graph;
 
-use Fhaculty\Graph\Graph;
+use Clue\GraphComposer\Exclusion\Dependency\ChainedDependencyRule;
+use Clue\GraphComposer\Exclusion\Dependency\DependencyRule;
+use Clue\GraphComposer\Exclusion\Package\ChainedPackageRule;
+use Clue\GraphComposer\Exclusion\Package\PackageRule;
 use Fhaculty\Graph\Attribute\AttributeAware;
 use Fhaculty\Graph\Attribute\AttributeBagNamespaced;
+use Fhaculty\Graph\Graph;
 use Graphp\GraphViz\GraphViz;
+use JMS\Composer\Graph\PackageNode;
 
 class GraphComposer
 {
@@ -13,21 +18,24 @@ class GraphComposer
         'fillcolor' => '#eeeeee',
         'style' => 'filled, rounded',
         'shape' => 'box',
-        'fontcolor' => '#314B5F'
+        'fontcolor' => '#314B5F',
     );
 
     private $layoutVertexRoot = array(
-        'style' => 'filled, rounded, bold'
+        'style' => 'filled, rounded, bold',
     );
 
     private $layoutEdge = array(
         'fontcolor' => '#767676',
         'fontsize' => 10,
-        'color' => '#1A2833'
+        'color' => '#1A2833',
     );
 
     private $layoutEdgeDev = array(
-        'style' => 'dashed'
+        'style' => 'dashed',
+        'fontcolor' => '#767676',
+        'fontsize' => 10,
+        'color' => '#1A2833',
     );
 
     private $dependencyGraph;
@@ -38,19 +46,51 @@ class GraphComposer
     private $graphviz;
 
     /**
+     * The maximum depth of dependency to display.
      *
-     * @param string $dir
-     * @param GraphViz|null $graphviz
+     * @var int
      */
-    public function __construct($dir, GraphViz $graphviz = null)
+    private $maxDepth;
+
+    /**
+     * @var PackageRule
+     */
+    private $packageExclusionRule;
+
+    /**
+     * @var DependencyRule
+     */
+    private $dependencyExclusionRule;
+
+    public function __construct(
+        $dir,
+        GraphViz $graphviz = null,
+        PackageRule $packageExclusionRule = null,
+        DependencyRule $dependencyExclusionRule = null,
+        $maxDepth = PHP_INT_MAX)
     {
         if ($graphviz === null) {
             $graphviz = new GraphViz();
             $graphviz->setFormat('svg');
         }
+
+        if ($packageExclusionRule === null) {
+            $packageExclusionRule = new ChainedPackageRule();
+            //$packageExclusionRule->add(new NoPhpExtensionRule());
+            //$packageExclusionRule->add(new ExcludeByNamePackageRule('#^php$#'));
+        }
+
+        if ($dependencyExclusionRule === null) {
+            $dependencyExclusionRule = new ChainedDependencyRule();
+            // $dependencyExclusionRule->add(new NoDevDependencyRule());
+        }
+
         $analyzer = new \JMS\Composer\DependencyAnalyzer();
         $this->dependencyGraph = $analyzer->analyze($dir);
         $this->graphviz = $graphviz;
+        $this->packageExclusionRule = $packageExclusionRule;
+        $this->dependencyExclusionRule = $dependencyExclusionRule;
+        $this->maxDepth = $maxDepth;
     }
 
     /**
@@ -62,36 +102,68 @@ class GraphComposer
     {
         $graph = new Graph();
 
-        foreach ($this->dependencyGraph->getPackages() as $package) {
-            $name = $package->getName();
-            $start = $graph->createVertex($name, true);
+        $drawnPackages = array();
+        $rootPackage = $this->dependencyGraph->getRootPackage();
+        $this->drawPackageNode($graph, $rootPackage, $drawnPackages, $this->layoutVertexRoot);
 
-            $label = $name;
-            if ($package->getVersion() !== null) {
-                $label .= ': ' . $package->getVersion();
+        return $graph;
+    }
+
+    private function drawPackageNode(
+        Graph $graph,
+        PackageNode $packageNode,
+        array &$drawnPackages,
+        array $layoutVertex = null,
+        $depth = 0)
+    {
+        if (count($drawnPackages) && $this->packageExclusionRule->isExcluded($packageNode)) {
+            return null;
+        }
+
+        $name = $packageNode->getName();
+        if (isset($drawnPackages[$name])) {
+            return $drawnPackages[$name];
+        }
+
+        if ($depth > $this->maxDepth) {
+            return null;
+        }
+
+        if ($layoutVertex === null) {
+            $layoutVertex = $this->layoutVertex;
+        }
+
+        $label = $name;
+        if ($packageNode->getVersion()) {
+            $label .= ': ' .$packageNode->getVersion();
+        }
+        $vertex = $graph->createVertex($name, true);
+        $this->setLayout($vertex, array('label' => $label) + $layoutVertex);
+        $drawnPackages[$name] = $vertex;
+
+        foreach ($packageNode->getOutEdges() as $dependency)
+        {
+            if ($this->dependencyExclusionRule->isExcluded($dependency)) {
+                continue;
             }
 
-            $this->setLayout($start, array('label' => $label) + $this->layoutVertex);
+            // never show dev dependencies of dependencies:
+            // they are not relevant for the current application and are ignored by composer
+            if ($depth > 0 && $dependency->isDevDependency()) {
+                continue;
+            }
 
-            foreach ($package->getOutEdges() as $requires) {
-                $targetName = $requires->getDestPackage()->getName();
-                $target = $graph->createVertex($targetName, true);
+            $targetVertex = $this->drawPackageNode($graph, $dependency->getDestPackage(), $drawnPackages, null, $depth + 1);
 
-                $label = $requires->getVersionConstraint();
-
-                $edge = $start->createEdgeTo($target);
-                $this->setLayout($edge, array('label' => $label) + $this->layoutEdge);
-
-                if ($requires->isDevDependency()) {
-                    $this->setLayout($edge, $this->layoutEdgeDev);
-                }
+            if ($targetVertex && $depth < $this->maxDepth) {
+                $label = $dependency->getVersionConstraint();
+                $edge = $vertex->createEdgeTo($targetVertex);
+                $layoutEdge = $dependency->isDevDependency() ? $this->layoutEdgeDev : $this->layoutEdge;
+                $this->setLayout($edge, array('label' => $label) + $layoutEdge);
             }
         }
 
-        $root = $graph->getVertex($this->dependencyGraph->getRootPackage()->getName());
-        $this->setLayout($root, $this->layoutVertexRoot);
-
-        return $graph;
+        return $vertex;
     }
 
     private function setLayout(AttributeAware $entity, array $layout)


### PR DESCRIPTION
Dev dependencies of dependencies are not shown anymore, because they are not relevant for the current package.

* `--no-dev` will hide dev dependencies
* `--no-php` will hide the constraints regarding the PHP version
* `--no-ext` will hide PHP extensions
* `--depth` will limit the depth of the generated graph
* `--exclude-regex` allows to apply regular expressions to hide packages
* `--only-regex` show only packages with their name matching the expression
* `--exclude-type` exclude pacakges with given type
* `--only-type` only show packages of given type

The filters are never applied to the root packge.

To apply these filters the packages must be rendered in the correct order. Before the packages were drawn "randomly" and were connected later on. Now packages are drawn from root package and only if they are a dependency of a package. This allow filtering for dependencies and packages. If a package (node) is missing, then the dependency (edge) is not shown. Vice versa the dependency (edge) is not shown when the package (node) is not available.

**New**
![output_exfsyf](https://user-images.githubusercontent.com/1222377/52131159-62dc2a80-263c-11e9-9a82-0ecf25647745.gif)

**Old**
![output_n3qgvf](https://user-images.githubusercontent.com/1222377/52131177-6bccfc00-263c-11e9-928c-2846c50c5311.gif)

## Open TODOs:

* [x] Update documentation (add examples etc.)
* [x] Fix PHPUnit tests (they are surprisingly still working ;-))
* [x] Cleanup code / code style etc.
* [x] Update CHANGELOG
* [x] Visualize rendering process so that new algo to render graph is understood (compare old vs. new)
