### PR TITLE
Forward compatibility with upcoming symfony/console v5 and current v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
       dist: precise
     - php: 7.2
       script: composer build
+    - php: 7.2
+      install: []
+      script: composer install --dry-run --working-dir=tests/install-as-dep
   allow_failures:
     - php: hhvm
 

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
     "homepage": "https://github.com/clue/graph-composer",
     "license": "MIT",
     "require": {
-        "php": "^5.3.6 || ^7.0",
+        "php": ">=5.3.6",
         "clue/graph": "^0.9.0",
         "graphp/graphviz": "^0.2.0",
         "jms/composer-deps-analyzer": "0.1.*",
-        "symfony/console": "^3.0 || ^2.1"
+        "symfony/console": "^5.0 || ^4.0 || ^3.0 || ^2.1"
     },
     "require-dev": {
         "clue/phar-composer": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2625dd774840b0bc680f6b41ef18bbdd",
+    "content-hash": "a7158f16382fcab8c2ed71f5b46ab1dd",
     "packages": [
         {
             "name": "clue/graph",
@@ -1317,6 +1317,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2015-10-02T06:51:40+00:00"
         },
         {
@@ -1953,7 +1954,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.3.6 || ^7.0"
+        "php": ">=5.3.6"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/src/Clue/GraphComposer/Command/Export.php
+++ b/src/Clue/GraphComposer/Command/Export.php
@@ -54,5 +54,7 @@ class Export extends Command
         } else {
             readfile($path);
         }
+
+        return 0;
     }
 }

--- a/src/Clue/GraphComposer/Command/Show.php
+++ b/src/Clue/GraphComposer/Command/Show.php
@@ -25,5 +25,7 @@ class Show extends Command
         $graph = new GraphComposer($input->getArgument('dir'));
         $graph->setFormat($input->getOption('format'));
         $graph->displayGraph();
+
+        return 0;
     }
 }

--- a/tests/install-as-dep/composer.json
+++ b/tests/install-as-dep/composer.json
@@ -1,0 +1,14 @@
+{
+    "require": {
+        "symfony/console": "^4.0"
+    },
+    "require-dev": {
+        "clue/graph-composer": "*@dev"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../"
+        }
+    ]
+}


### PR DESCRIPTION
This changeset includes a simple test to verify installation of this
project as dependency works alongside symfony/console:^4.0.

Symfony 5 has yet to be released (ETA this month), but some manual tests
against the current development version suggest this is supported as
well.

Supersedes / closes #47 and #46
Builds on top of #34 