### PR TITLE
Test on PHP 8.3 and update test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php:
+          - 8.3
           - 8.2
           - 8.1
           - 8.0


### PR DESCRIPTION
This PR only updates to PHP 8.3 so far, because upgrading to PHP 8.4 needs avoiding implicitly nullable types first.
Will try to solve this in another PR.
Builds on top of #69 and #63.